### PR TITLE
Fix - configure GitHub action to check out from production instead of main

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Once per day at midnight UTC (8am MYT)
-  
 
 jobs:
   build:
@@ -16,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: production
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
<!--NAMING CONVENTION: FEAT/FIX/REFACTOR nameOfContribution!-->

**What type of change did you make?**
- fix (fix an issue)

**Changes**
<!-- Briefly describe your changes here !-->
1. Configured GitHub Action to check out from `production` instead of `main`. This is required because the updates are being pushed to `main`. We were getting an error where we were checking out from main instead of production, causing the refs to be rejected.

Note: this does not fix the Workflow run failing when branch is up-to-date, but I'm not worried about this


**Checklist:**

- [x] My changes don't break anything
- [x] I have removed all console logs
- [x] I have applied prettier before pushing

Mention someone for review
@sidharrth2002 
