### PR TITLE
fix squeezed images in modal

### DIFF
--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -370,7 +370,6 @@ const Home = () => {
                     src={selectedMarker?.image}
                     width="100%"
                     maxWidth="200px"
-                    h="100%"
                     marginRight="1rem"
                   />
                 </Box>


### PR DESCRIPTION
<!--NAMING CONVENTION: FEAT/FIX/REFACTOR nameOfContribution!-->

**What type of change did you make?**
Either:
- fix (fix an issue)

**Changes**
<!-- Briefly describe your changes here !-->
1. Images stretching to width of container
2. Removed height: 100%

**Screenshots:**

**Link to Trello Card (if applicable):**

**Checklist:**

- [x] My changes don't break anything
- [x] I have removed all console logs
- [x] I have applied prettier before pushing

Mention someone for review
@someone
